### PR TITLE
Enable car follow waypoints and desired speed

### DIFF
--- a/ros/src/twist_controller/launch/dbw.launch
+++ b/ros/src/twist_controller/launch/dbw.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="twist_controller" type="dbw_node.py" name="dbw_node">
+    <node pkg="twist_controller" type="dbw_node.py" name="dbw_node" output="screen">
         <param name="vehicle_mass" value="1736.35" />
         <param name="fuel_capacity" value="13.5" />
         <param name="brake_deadband" value=".1" />

--- a/ros/src/twist_controller/launch/dbw_sim.launch
+++ b/ros/src/twist_controller/launch/dbw_sim.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="twist_controller" type="dbw_node.py" name="dbw_node">
+    <node pkg="twist_controller" type="dbw_node.py" name="dbw_node" output="screen">
         <param name="vehicle_mass" value="1080." />
         <param name="fuel_capacity" value="0." />
         <param name="brake_deadband" value=".2" />

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,6 +1,9 @@
-
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
+
+from pid import PID
+from lowpass import LowPassFilter
+from yaw_controller import YawController
 
 
 class Controller(object):
@@ -11,4 +14,4 @@ class Controller(object):
     def control(self, *args, **kwargs):
         # TODO: Change the arg, kwarg list to suit your needs
         # Return throttle, brake, steer
-        return 1., 0., 0.
+        return 0.5, 0., 0.

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,17 +1,85 @@
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
 
+import rospy
+import math
+
 from pid import PID
-from lowpass import LowPassFilter
 from yaw_controller import YawController
 
 
 class Controller(object):
     def __init__(self, *args, **kwargs):
-        # TODO: Implement
-        pass
+        self.pid_controller = PID(1.0, 0.2, 4)
+        self.yaw_controller = YawController(
+            wheel_base=kwargs['wheel_base'],
+            steer_ratio=kwargs['steer_ratio'],
+            min_speed=kwargs['min_speed'],
+            max_lat_accel=kwargs['max_lat_accel'],
+            max_steer_angle=kwargs['max_steer_angle']
+        )
 
-    def control(self, *args, **kwargs):
-        # TODO: Change the arg, kwarg list to suit your needs
-        # Return throttle, brake, steer
-        return 0.5, 0., 0.
+        self.prev_time = None
+        self.prev_throttle = 0
+
+        total_vehicle_mass = kwargs['vehicle_mass'] + kwargs['fuel_capacity'] * GAS_DENSITY
+        self.max_brake_torque = total_vehicle_mass * abs(kwargs['decel_limit']) * kwargs['wheel_radius']
+
+    def control(self, twist_cmd, current_velocity, dbw_enabled):
+        """
+        :return: (throttle, brake, steer)
+        """
+
+        throttle = 0.0
+        brake = 0.0
+        steering = 0.0
+
+        if not dbw_enabled:
+            self.pid_controller.reset()
+            return throttle, brake, steering
+
+        if not all((twist_cmd, current_velocity)):
+            return throttle, brake, steering
+
+        desired_linear_velocity = twist_cmd.twist.linear.x
+        desired_angular_velocity = twist_cmd.twist.angular.z
+
+        current_linear_velocity = current_velocity.twist.linear.x
+
+        steering = self.yaw_controller.get_steering(
+            linear_velocity=desired_linear_velocity,
+            angular_velocity=desired_angular_velocity,
+            current_velocity=current_linear_velocity)
+
+        if not self.prev_time:
+            self.prev_time = rospy.get_time()
+            return throttle, brake, steering
+
+        delta_v = desired_linear_velocity - current_linear_velocity
+        delta_t = float(rospy.get_time() - self.prev_time)
+        self.prev_time = rospy.get_time()
+
+        control = self.pid_controller.step(
+            error=delta_v,
+            sample_time=delta_t
+        )
+        # throttle : [0 .. 1]
+        # brake : torque (N*m) = F(acceleration, weight, wheel radius)
+
+
+        if control > 0:
+            throttle = 2 * math.tanh(control)
+            throttle = max(0.0, min(1.0, throttle))
+            if throttle - self.prev_throttle > 0.1:
+                throttle = self.prev_throttle + 0.1
+            brake = 0.0
+        elif control >= -1:
+            throttle = 0.0
+            brake = 0.0
+        else:
+            throttle = 0.0
+            brake = min(self.max_brake_torque, -control + 1)
+
+        self.prev_throttle = throttle
+
+        return throttle, brake, steering


### PR DESCRIPTION
Changes include:
    1. use of PID controller to adjust throttle and break
     to maintain desired speed
    2. use of YawController to steer car and follow proposed
     waypoints
    3. compute and use max_brake_torque to limit brake force
    4. implement simple logic to translate control signals
     into throttle and brake signals