### PR TITLE
add functions to check and skip the current closest waypoint

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -77,30 +77,23 @@ class WaypointUpdater(object):
     def set_waypoint_velocity(self, waypoints, waypoint, velocity):
         waypoints[waypoint].twist.twist.linear.x = velocity
 
-    def distance(self, waypoints, wp1, wp2):
-        dist = 0
-        dl = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2 + (a.z-b.z)**2)
-        for i in range(wp1, wp2+1):
-            dist += dl(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
-            wp1 = i
-        return dist
+    def distance(self, car_pose, waypoint):
+        dist_x = car_pose.position.x - waypoint.pose.pose.position.x
+        dist_y = car_pose.position.y - waypoint.pose.pose.position.y
+        return math.sqrt(dist_x**2 + dist_y**2)
 
     def prepare_lookahead_waypoints(self):
         if self.waypoints is None or self.current_pose is None:
             rospy.loginfo("Base waypoint or current pose info are missing. Not publishing waypoints ...")
             return None
         else:
-            # current pose of the car (x and y coordinates)
-            car_x, car_y = self.current_pose.position.x, self.current_pose.position.y
             closest_dist = 1000000000  # initialize with very large value
             closest_wp_pos = None  # closest waypoint's position (among the waypoint list)
             for i in range(len(self.waypoints)):
                 # extract waypoint coordinates
                 waypoint = self.waypoints[i]
-                wp_x = waypoint.pose.pose.position.x
-                wp_y = waypoint.pose.pose.position.y
                 # calculate distance between the car's pose to each waypoint
-                dist = math.sqrt((car_x-wp_x)**2 + (car_y-wp_y)**2)
+                dist = self.distance(self.current_pose, waypoint)
                 # search for position of closest waypoint to the car
                 if dist < closest_dist:
                     closest_dist = dist

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -112,7 +112,6 @@ class WaypointUpdater(object):
                 if dist < closest_dist:
                     closest_dist = dist
                     closest_wp_pos = i
-
             # check if we already passed the closest waypoint we found
             # get heading of closest waypoint
             theta_waypoint = self.closest_waypoint_heading(self.current_pose, self.waypoints, closest_wp_pos)
@@ -120,11 +119,13 @@ class WaypointUpdater(object):
             theta_car = self.car_pose_heading(self.current_pose)
             # check if we should skip the current closest waypoint (in case we passed it already)
             diff_angle = math.fabs(theta_car-theta_waypoint)
-            rospy.loginfo("Theta Waypoint: %.3f, Theta Car: %.3f, Diff: %.3f" % (theta_waypoint, theta_car, diff_angle))
+            # rospy.loginfo("Theta Waypoint: %.3f, Theta Car: %.3f, Diff: %.3f" % (theta_waypoint, theta_car, diff_angle))
             if diff_angle > math.pi / 4.0:
                 # skip to next closest waypoint
-                # rospy.loginfo("closest waypoint skipped. Next closest one picked ...")
+                rospy.loginfo("closest waypoint skipped. Next closest one picked ...")  # debug only
                 closest_wp_pos += 1
+            else:
+                rospy.loginfo("current closest waypoint maintained ...")  # debug only
 
             # create list of waypoints starting from index: closest_wp_ros
             seq = cycle(self.waypoints)  # loop string of waypoints


### PR DESCRIPTION
1. Rewrite function distance and apply it to make the code concise
2. Add functions to observe heading of the car (from topic:current pose) and heading of the closest waypoint (from topic:waypoint with the closest waypoint index). If the difference is larger than pi/4, it probably means we already get passed it. So, we skip the current closest waypoint to another one in front. I uncomment loginfo to make it print message in the terminal. This can be commented out once we are all satisfied with this PR.