### PR TITLE
Adding law of physics into car path planning

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, Int32
 from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 from geometry_msgs.msg import TwistStamped
 import math
@@ -70,12 +70,17 @@ class DBWNode(object):
         self.dbw_enabled = False
         self.current_velocity = None
         self.twist_cmd = None
+        self.driving_mode = None
 
         rospy.Subscriber('/current_velocity', TwistStamped, self.current_velocity_cb)
         rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cmd_cb)
         rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
+        rospy.Subscriber('/driving_mode', Int32, self.driving_mode_cb)
 
         self.loop()
+
+    def driving_mode_cb(self, msg):
+        self.driving_mode = msg.data
 
     def current_velocity_cb(self, msg):
         self.current_velocity = msg
@@ -94,7 +99,8 @@ class DBWNode(object):
                 throttle, brake, steering = self.controller.control(
                     twist_cmd=self.twist_cmd,
                     current_velocity=self.current_velocity,
-                    dbw_enabled=self.dbw_enabled)
+                    dbw_enabled=self.dbw_enabled,
+                    driving_mode=self.driving_mode)
 
                 self.publish(throttle, brake, steering)
 

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -13,7 +13,7 @@ from lowpass import LowPassFilter
 class Controller(object):
     def __init__(self, *args, **kwargs):
         self.pid_controller = PID(1.0, 0.005, 0.0)
-        self.brake_lpf = LowPassFilter(0.2, 0.1)
+        self.brake_lpf = LowPassFilter(2, 1)
 
         self.yaw_controller = YawController(
             wheel_base=kwargs['wheel_base'],
@@ -31,7 +31,7 @@ class Controller(object):
         total_vehicle_mass = kwargs['vehicle_mass'] + kwargs['fuel_capacity'] * GAS_DENSITY
         self.max_brake_torque = total_vehicle_mass * abs(kwargs['decel_limit']) * kwargs['wheel_radius']
 
-    def control(self, twist_cmd, current_velocity, dbw_enabled):
+    def control(self, twist_cmd, current_velocity, dbw_enabled, driving_mode):
         """
         :return: (throttle, brake, steer)
         """
@@ -74,20 +74,43 @@ class Controller(object):
             error=delta_v,
             sample_time=delta_t
         )
+
         # throttle : [0 .. 1]
         # brake : torque (N*m) = F(acceleration, weight, wheel radius)
 
-        if desired_linear_velocity == 0:
-            control = -1
+        action = 0
 
-        if control > 0:
+        # lets prevent ping-pong between throttle and brake
+        # when we try to maintain requested speed
+
+        if driving_mode == 1:
+            # path planner is accelerating the car
+            if delta_v > 0:
+                # activate throttle right away if we are below desired speed limit
+                action = 1
+            if delta_v <= -0.2:
+                # activate brake only if the speed difference is bigger that
+                action = -1
+
+        if driving_mode == -1:
+            # path planner is slowing the car
+            if delta_v < -0.1:
+                # let the car slow down a bit on its own
+                # if this is not enough - the activate brake
+                action = -1
+            if delta_v >= 0.2:
+                # we slowed down too much - lets spped up a bit
+                action = 1
+
+        if desired_linear_velocity == 0:
+            action = -1
+
+        if action > 0:
             throttle = math.tanh(control)
             throttle = max(0.0, min(THROTTLE_MAX, throttle))
-            brake = 0.0
-        else:
-            throttle = 0.0
-
+        if action < 0:
             brake = 0.4*self.max_brake_torque*math.tanh(math.fabs(control))
+
             if desired_linear_velocity <= ONE_MPH * 1.0:
                 brake = 0.4*self.max_brake_torque
                 if current_linear_velocity <= ONE_MPH * 5.0:

--- a/ros/src/waypoint_updater/pid.py
+++ b/ros/src/waypoint_updater/pid.py
@@ -1,0 +1,37 @@
+
+MIN_NUM = float('-inf')
+MAX_NUM = float('inf')
+
+
+class PID(object):
+    def __init__(self, kp, ki, kd, mn=MIN_NUM, mx=MAX_NUM):
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.min = mn
+        self.max = mx
+
+        self.int_val = self.last_int_val = self.last_error = 0.
+
+    def reset(self):
+        self.int_val = 0.0
+        self.last_int_val = 0.0
+
+    def step(self, error, sample_time):
+        self.last_int_val = self.int_val
+
+        integral = self.int_val + error * sample_time;
+        derivative = (error - self.last_error) / sample_time;
+
+        y = self.kp * error + self.ki * self.int_val + self.kd * derivative;
+        val = max(self.min, min(y, self.max))
+
+        if val > self.max:
+            val = self.max
+        elif val < self.min:
+            val = self.min
+        else:
+            self.int_val = integral
+        self.last_error = error
+
+        return val

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -45,6 +45,8 @@ class WaypointUpdater(object):
         # Publisher
         # This topic: /final_waypoints is subscribed from node pure_pursuit in waypoint_follower package
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
+        self.driving_mode_pub = rospy.Publisher('driving_mode', Int32, queue_size=1)
+
 
         # Initialize important parameters
         self.current_velocity = 0.0
@@ -232,6 +234,10 @@ class WaypointUpdater(object):
         lane.header.stamp = rospy.Time(0)
         lane.waypoints = waypoints
         self.final_waypoints_pub.publish(lane)
+        if self.is_braking:
+            self.driving_mode_pub.publish(-1)
+        else:
+            self.driving_mode_pub.publish(1)
 
     def mph_to_mps(self, data):
         return data * 0.447


### PR DESCRIPTION
This PR is fixing two important corner cases for the path planning task:
1. When approaching a traffic light, we compute if it is feasible to stop the car given its brakes capability, current speed, and the distance to the traffic light
2. Helping the car to stay in lane: and follow waypoints. When we detect the car is too far from the waypoints, we activate brakes to put the car on track 
3. mitigating ping-pong behavior when the car is maintaining desired speed by introducing a small slack in speed , given current driving mode (accel / decel )

@TharatchSiri @igolas0 please have a look 