### PR TITLE
tl_detector: pre-compute associations: tl_position -> waypoint_id

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -50,6 +50,14 @@ class TLDetector(object):
         self.last_wp = -1
         self.state_count = 0
 
+        self.stop_line_data = []
+
+        # List of positions that correspond to the line to stop in front of for a given intersection
+        stop_line_positions = self.config['stop_line_positions']
+        for index, stop_line in enumerate(stop_line_positions):
+            stop_line_wp = self.get_closest_waypoint(stop_line)
+            self.stop_line_data.append((index, stop_line_wp))
+
         rospy.spin()
 
     def pose_cb(self, msg):
@@ -154,10 +162,9 @@ class TLDetector(object):
         stop_line_positions = self.config['stop_line_positions']
         if(self.pose and self.waypoints and self.light_classifier):
             car_position = self.get_closest_waypoint([self.pose.pose.position.x, self.pose.pose.position.y])
-        #TODO find the closest visible traffic light (if one exists)
+
             light_wp = 9999
-            for index, stop_line in enumerate(stop_line_positions):
-                stop_line_wp = self.get_closest_waypoint(stop_line)
+            for index, stop_line_wp in self.stop_line_data:
                 num_wp_ahead = stop_line_wp - car_position
                 if (stop_line_wp > car_position) and ( num_wp_ahead < light_wp ) and (num_wp_ahead < 200):
                     light_wp = stop_line_wp


### PR DESCRIPTION
Updates include:
1. remove continuous computation tl_pos -> wp_id in
 process_traffic_lights which gets executed every time we receive
 a new camera image
2. pre-compute mapping and re-use it

@mplaza please have a look 